### PR TITLE
Fix response parsing for rkt stop.

### DIFF
--- a/rktlet/cli/cli.go
+++ b/rktlet/cli/cli.go
@@ -133,12 +133,13 @@ func (c *cli) RunCommand(subcmd string, args ...string) ([]string, error) {
 	cmd := c.execer.Command(command[0], command[1:]...)
 
 	out, err := cmd.CombinedOutput()
+	result := strings.Split(strings.TrimSpace(string(out)), "\n")
 	if err != nil {
 		glog.Warningf("rkt: cmd %v %v errored with %v", subcmd, args, err)
-		return nil, fmt.Errorf("failed to run %v %v: %v\noutput: %s", subcmd, args, err, out)
+		return result, fmt.Errorf("failed to run %v %v: %v\noutput: %s", subcmd, args, err, out)
 	}
 
-	return strings.Split(strings.TrimSpace(string(out)), "\n"), nil
+	return result, nil
 }
 
 // Command returns the final rkt command that will be executed by RunCommand.

--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -82,13 +82,16 @@ func (r *RktRuntime) RunPodSandbox(ctx context.Context, req *runtimeApi.RunPodSa
 
 func (r *RktRuntime) StopPodSandbox(ctx context.Context, req *runtimeApi.StopPodSandboxRequest) (*runtimeApi.StopPodSandboxResponse, error) {
 	respLines, err := r.RunCommand("stop", req.GetPodSandboxId())
-	// TODO, structured output will be so much nicer!
-	for _, line := range respLines {
-		if strings.HasSuffix(line, "is not running") {
-			return &runtimeApi.StopPodSandboxResponse{}, nil
+	if err != nil {
+		// TODO, structured output will be so much nicer!
+		for _, line := range respLines {
+			if strings.HasSuffix(line, "is not running") {
+				return &runtimeApi.StopPodSandboxResponse{}, nil
+			}
 		}
+		return nil, err
 	}
-	return nil, err
+	return &runtimeApi.StopPodSandboxResponse{}, err
 }
 
 func (r *RktRuntime) RemovePodSandbox(ctx context.Context, req *runtimeApi.RemovePodSandboxRequest) (*runtimeApi.RemovePodSandboxResponse, error) {


### PR DESCRIPTION
Return the result of CLI even there is a error so that we can
treat rkt stop on a non-running pod as success.

Can drop this once https://github.com/coreos/rkt/pull/3220 is merged.