### PR TITLE
CRI: Support exposing ports.

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -313,6 +313,19 @@ func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile st
 		// https://github.com/kubernetes/kubernetes/pull/33709 is merged.
 	}
 
+	// Add port mappings only if it's not hostnetwork.
+	if !req.GetConfig().GetLinux().GetNamespaceOptions().GetHostNetwork() {
+		for _, portMapping := range req.Config.PortMappings {
+			if portMapping.GetHostPort() == 0 {
+				// If no host port is specified, then ignore.
+				// TODO(yifan): Do this check in kubelet.
+				continue
+			}
+			portArg := generatePortArgs(portMapping)
+			cmd = append(cmd, portArg)
+		}
+	}
+
 	// Generate annotations.
 	var labels, annotations []string
 	for k, v := range req.Config.Labels {
@@ -448,4 +461,20 @@ func cpuSharesToMilliCores(cpushare int64) int64 {
 
 func cpuQuotaToMilliCores(cpuQuota, cpuPeriod int64) int64 {
 	return cpuQuota * 1000 / cpuPeriod
+}
+
+// generatePortArgs returns the `--port` argument derived from the port mapping.
+func generatePortArgs(port *runtimeApi.PortMapping) string {
+	protocol := strings.ToLower(port.Protocol.String())
+	containerPort := port.GetContainerPort()
+	hostPort := port.GetHostPort()
+	hostIP := port.GetHostIp()
+	if hostIP == "" {
+		hostIP = "0.0.0.0"
+	}
+	// The name is in the format of "protocol-containerPort-hostPort",
+	// e.g. "tcp-80-8080", which satisfies the ACName format.
+	name := fmt.Sprintf("%s-%d-%d", protocol, containerPort, hostPort)
+
+	return fmt.Sprintf("--port=%s:%s:%d:%s:%d", name, protocol, containerPort, hostIP, hostPort)
 }

--- a/rktlet/runtime/helpers_test.go
+++ b/rktlet/runtime/helpers_test.go
@@ -160,3 +160,41 @@ func TestPassFilter(t *testing.T) {
 		assert.Equal(t, tt.result, passFilter(tt.container, tt.filter), testHint)
 	}
 }
+
+func TestGeneratePortArgs(t *testing.T) {
+	protocol := runtimeApi.Protocol_TCP
+	containerPort := int32(80)
+	hostPort := int32(8080)
+	hostIP := "127.0.0.1"
+
+	tests := []struct {
+		port   *runtimeApi.PortMapping
+		result string
+	}{
+		// Case 0.
+		{
+			&runtimeApi.PortMapping{
+				Protocol:      &protocol,
+				ContainerPort: &containerPort,
+				HostPort:      &hostPort,
+				HostIp:        &hostIP,
+			},
+			"--port=tcp-80-8080:tcp:80:127.0.0.1:8080",
+		},
+
+		// Case 1, empty host IP, should default to "0.0.0.0".
+		{
+			&runtimeApi.PortMapping{
+				Protocol:      &protocol,
+				ContainerPort: &containerPort,
+				HostPort:      &hostPort,
+			},
+			"--port=tcp-80-8080:tcp:80:0.0.0.0:8080",
+		},
+	}
+
+	for i, tt := range tests {
+		testHint := fmt.Sprintf("test case #%d", i)
+		assert.Equal(t, tt.result, generatePortArgs(tt.port), testHint)
+	}
+}


### PR DESCRIPTION
cc @euank 

Would modify the upstream to remove unnecessary `Name` field, and the skip when `host port == 0`.