### PR TITLE
cli: fix flag reflection

### DIFF
--- a/cmd/server/options/options.go
+++ b/cmd/server/options/options.go
@@ -35,6 +35,6 @@ func NewRktletServer() *RktletServer {
 
 func (s *RktletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RktPath, "rkt-path", s.RktPath, "Path of rkt binary. Leave empty to use the first rkt in $PATH.")
-	fs.StringVar(&s.RktDatadir, "rkt-data-dir", s.RktPath, "Path to rkt's data directory. Defaults to '/var/lib/rktlet/data'.")
+	fs.StringVar(&s.RktDatadir, "rkt-data-dir", s.RktDatadir, "Path to rkt's data directory. Defaults to '/var/lib/rktlet/data'.")
 	fs.StringVar(&s.StreamServerAddress, "stream-server-address", s.StreamServerAddress, "Address to listen on for api-server streaming requests. MUST BE SECURED BY SOME EXTERNAL MECHANISM.")
 }

--- a/rktlet/cli/cli_test.go
+++ b/rktlet/cli/cli_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFlagFormOfStruct(t *testing.T) {
+
+	testCases := []struct {
+		in  CLIConfig
+		out []string
+	}{
+		{
+			in: CLIConfig{
+				Debug: true,
+			},
+			out: []string{"--debug=true"},
+		},
+		{
+			in: CLIConfig{
+				Debug: true,
+				Dir:   "foo",
+			},
+			out: []string{"--debug=true", "--dir=foo"},
+		},
+		{
+			in: CLIConfig{
+				Debug:           true,
+				InsecureOptions: []string{"all", "all-run"},
+			},
+			out: []string{"--debug=true", "--insecure-options=all,all-run"},
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			flags := getFlagFormOfStruct(testCase.in)
+			assert.Equal(t, testCase.out, flags)
+		})
+	}
+
+}

--- a/rktlet/cli/init.go
+++ b/rktlet/cli/init.go
@@ -59,7 +59,7 @@ func (s *systemd) StartProcess(cgroupParent, command string, args ...string) (id
 	cmd := s.execer.Command(cmdList[0], cmdList[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		glog.Warningf("rkt: systemd-run %v %v errored with %v", command, args, err)
+		glog.Warningf("rkt: %v errored with %v", cmdList, err)
 		return "", fmt.Errorf("failed to run systemd-run %v %v: %v\noutput: %s", command, args, err, out)
 	}
 	return unitName, nil

--- a/rktlet/image/imagestore.go
+++ b/rktlet/image/imagestore.go
@@ -214,7 +214,7 @@ func (s *ImageStore) PullImage(ctx context.Context, req *runtime.PullImageReques
 	}
 
 	// TODO auth
-	output, err := s.RunCommand("image", "fetch", "--no-store=true", "--insecure-options=image,ondisk", "--full=true", "docker://"+canonicalImageName)
+	output, err := s.RunCommand("image", "fetch", "--no-store=true", "--full=true", "docker://"+canonicalImageName)
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch image %q: %v", canonicalImageName, err)

--- a/rktlet/rktlet.go
+++ b/rktlet/rktlet.go
@@ -50,7 +50,8 @@ func New(config *Config) (ContainerAndImageService, error) {
 	}
 
 	rktCli := cli.NewRktCLI(config.RktPath, execer, cli.CLIConfig{
-		Dir: config.RktDatadir,
+		InsecureOptions: []string{"image", "ondisk"},
+		Dir:             config.RktDatadir,
 	})
 	init := cli.NewSystemd(systemdRunPath, execer)
 


### PR DESCRIPTION
Prior to this change, it emitted no flags due to a flipped `IsValid`
check.

This fixes the fact that the configured data directory was totally ignored.