### PR TITLE
docs: add a section about the datadir default

### DIFF
--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -43,3 +43,19 @@ $ kubectl get pods
 NAME      READY     STATUS    RESTARTS   AGE
 nginx     1/1       Running   0          57s
 ```
+
+### Using the rkt cli
+
+By default, `rktlet` will configure rkt to use a data directory in
+`/var/lib/rktlet/data`. It may be convenient to create a wrapper script to
+interact with this data directory.
+
+To view `rktlet` started pods and applications, the following commands might help
+
+```shell
+$ export RKT_EXPERIMENT_APP=true
+$ sudo -E rkt --dir=/var/lib/rktlet/data list
+....
+$ sudo -E rkt --dir=/var/lib/rktlet/data app list $uuid
+...
+```


### PR DESCRIPTION
In #48, default data directory was meant to be changed, but due to a bug (fixed in #61), that didn't take effect. Docs should have probably been edited in #48, but never too late to follow up :)