### PR TITLE
journal2cri: add release target

### DIFF
--- a/journal2cri/.gitignore
+++ b/journal2cri/.gitignore
@@ -1,1 +1,3 @@
 /bin/journal2cri
+/bin/docker/journal2cri
+

--- a/journal2cri/Dockerfile
+++ b/journal2cri/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:jessie
+MAINTAINER Rktlet Developers <https://github.com/kubernetes-incubator/rktlet>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y libsystemd-journal-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /journal/ /cri/
+COPY ./bin/docker/journal2cri /usr/bin/journal2cri
+
+VOLUME /journal
+VOLUME /cri
+
+CMD ["/usr/bin/journal2cri", "/journal", "/cri"]

--- a/journal2cri/Dockerfile.build
+++ b/journal2cri/Dockerfile.build
@@ -1,0 +1,12 @@
+FROM golang:1.7
+
+RUN apt-get -qq update
+RUN apt-get install -y libsystemd-journal-dev
+
+RUN mkdir -p /go/src/github.com/kubernetes-incubator/
+COPY . /go/src/github.com/kubernetes-incubator/rktlet/
+WORKDIR /go/src/github.com/kubernetes-incubator/rktlet/journal2cri
+
+VOLUME ["/go/src/github.com/kubernetes-incubator/rktlet/journal2cri/bin"]
+
+CMD make

--- a/journal2cri/Makefile
+++ b/journal2cri/Makefile
@@ -1,7 +1,28 @@
-.PHONY: all clean
+.PHONY: all docker docker-push release clean
 
-all: 
+TAG=0.0.1
+SOURCES := $(shell find ./journal2cri ./cmd -name '*.go')
+
+all: ./bin/journal2cri
+
+./bin/journal2cri: $(SOURCES)
 	go build -o bin/journal2cri ./cmd/journal2cri/main.go
+
+./bin/docker/journal2cri:
+	# Build context of parent directory to pick up our vendor folder
+	docker build -t localhost/journal2cri-builder:$(TAG) -f Dockerfile.build ..
+	docker run -v \
+		"$(shell pwd)/bin/docker/":/go/src/github.com/kubernetes-incubator/rktlet/journal2cri/bin \
+		localhost/journal2cri-builder:$(TAG)
+
+docker: ./bin/docker/journal2cri
+	docker build -t quay.io/coreos/rktlet-journal2cri:$(TAG) .
+
+docker-push: docker
+	docker push quay.io/coreos/rktlet-journal2cri:$(TAG)
+
+release: docker-push
 
 clean:
 	rm -f ./bin/journal2cri
+	rm -f ./bin/docker/journal2cri


### PR DESCRIPTION
This includes an option to build it in docker (required for release so
your crazy gentoo CFLAGS don't spit out a broken binary).

This is just another piecemeal step in merging in the logging changes that worked off in my branch.