### PR TITLE
runtime: fix list pod sandbox reference-overriding

### DIFF
--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -149,7 +149,8 @@ func (r *RktRuntime) ListPodSandbox(ctx context.Context, req *runtimeApi.ListPod
 	}
 
 	sandboxes := make([]*runtimeApi.PodSandbox, 0, len(pods))
-	for _, p := range pods {
+	for i, _ := range pods {
+		p := pods[i]
 		sandboxStatus, err := toPodSandboxStatus(&p)
 		if err != nil {
 			return nil, fmt.Errorf("error converting the status of pod sandbox %v: %v", p.UUID, err)

--- a/rktlet/runtime/pod_sandbox_test.go
+++ b/rktlet/runtime/pod_sandbox_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	rktlib "github.com/coreos/rkt/lib"
+	"github.com/coreos/rkt/networking/netinfo"
+	"github.com/kubernetes-incubator/rktlet/rktlet/cli/mocks"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+func strptr(s string) *string    { return &s }
+func int64ptr(i int64) *int64    { return &i }
+func uint32ptr(i uint32) *uint32 { return &i }
+
+var podsandboxReady = runtime.PodSandboxState_SANDBOX_READY
+var podsandboxNotReady = runtime.PodSandboxState_SANDBOX_NOTREADY
+
+func TestListPodSandbox(t *testing.T) {
+
+	testCases := []struct {
+		RktPods  []rktlib.Pod
+		Response runtime.ListPodSandboxResponse
+	}{
+		{ // simple case of 1 pod
+			RktPods: []rktlib.Pod{{
+				UUID:      "1",
+				AppNames:  []string{"0-foo", "1-bar"},
+				Networks:  []netinfo.NetInfo{{NetName: "default", IP: []byte{10, 0, 0, 1}}},
+				StartedAt: int64ptr(100),
+				UserAnnotations: map[string]string{
+					kubernetesReservedAnnoPodName:      "foo",
+					kubernetesReservedAnnoPodUid:       "0",
+					kubernetesReservedAnnoPodAttempt:   "0",
+					kubernetesReservedAnnoPodNamespace: "default",
+				},
+				State: "running",
+			}},
+			Response: runtime.ListPodSandboxResponse{
+				Items: []*runtime.PodSandbox{{
+					Id:        strptr("1"),
+					CreatedAt: int64ptr(100),
+					State:     &podsandboxReady,
+					Metadata: &runtime.PodSandboxMetadata{
+						Name:      strptr("foo"),
+						Attempt:   uint32ptr(0),
+						Namespace: strptr("default"),
+						Uid:       strptr("0"),
+					},
+				}},
+			},
+		},
+		{ // 3 pods, 2 running
+			RktPods: []rktlib.Pod{
+				{
+					UUID:      "1",
+					AppNames:  []string{"0-foo", "1-bar"},
+					Networks:  []netinfo.NetInfo{{NetName: "default", IP: []byte{10, 0, 0, 1}}},
+					StartedAt: int64ptr(100),
+					UserAnnotations: map[string]string{
+						kubernetesReservedAnnoPodName:      "foo",
+						kubernetesReservedAnnoPodUid:       "0",
+						kubernetesReservedAnnoPodAttempt:   "0",
+						kubernetesReservedAnnoPodNamespace: "default",
+					},
+					State: "running",
+				},
+				{
+					UUID:      "2",
+					AppNames:  []string{"0-foo", "1-bar"},
+					Networks:  []netinfo.NetInfo{{NetName: "default", IP: []byte{10, 0, 0, 1}}},
+					StartedAt: int64ptr(102),
+					UserAnnotations: map[string]string{
+						kubernetesReservedAnnoPodName:      "foo2",
+						kubernetesReservedAnnoPodUid:       "10",
+						kubernetesReservedAnnoPodAttempt:   "5",
+						kubernetesReservedAnnoPodNamespace: "not-default",
+					},
+					State: "running",
+				},
+				{
+					UUID:      "3",
+					AppNames:  []string{"0-foo", "1-bar"},
+					Networks:  []netinfo.NetInfo{{NetName: "default", IP: []byte{10, 0, 0, 1}}},
+					StartedAt: int64ptr(104),
+					UserAnnotations: map[string]string{
+						kubernetesReservedAnnoPodName:      "foo3",
+						kubernetesReservedAnnoPodUid:       "0",
+						kubernetesReservedAnnoPodAttempt:   "0",
+						kubernetesReservedAnnoPodNamespace: "default",
+					},
+					State: "stopped",
+				},
+			},
+			Response: runtime.ListPodSandboxResponse{
+				Items: []*runtime.PodSandbox{
+					{
+						Id:        strptr("1"),
+						CreatedAt: int64ptr(100),
+						State:     &podsandboxReady,
+						Metadata: &runtime.PodSandboxMetadata{
+							Name:      strptr("foo"),
+							Attempt:   uint32ptr(0),
+							Namespace: strptr("default"),
+							Uid:       strptr("0"),
+						},
+					},
+					{
+						Id:        strptr("2"),
+						CreatedAt: int64ptr(102),
+						State:     &podsandboxReady,
+						Metadata: &runtime.PodSandboxMetadata{
+							Name:      strptr("foo2"),
+							Attempt:   uint32ptr(5),
+							Namespace: strptr("not-default"),
+							Uid:       strptr("10"),
+						},
+					},
+					{
+						Id:        strptr("3"),
+						CreatedAt: int64ptr(104),
+						State:     &podsandboxNotReady,
+						Metadata: &runtime.PodSandboxMetadata{
+							Name:      strptr("foo3"),
+							Attempt:   uint32ptr(0),
+							Namespace: strptr("default"),
+							Uid:       strptr("0"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		mockCli := new(mocks.CLI)
+		mockRuntime := &RktRuntime{
+			CLI: mockCli,
+		}
+
+		rktpodJson, err := json.Marshal(testCase.RktPods)
+		if err != nil {
+			t.Fatalf("%d: could not marshal input: %v", i, err)
+		}
+		mockCli.On("RunCommand", "list", []string{"--format=json"}).Return([]string{string(rktpodJson)}, nil)
+
+		resp, err := mockRuntime.ListPodSandbox(context.TODO(), &runtime.ListPodSandboxRequest{})
+		if err != nil {
+			t.Errorf("%d: error listing pod sandbox: %v", i, err)
+			continue
+		}
+
+		assert.Equal(t, testCase.Response, *resp)
+		mockCli.AssertExpectations(t)
+	}
+
+}


### PR DESCRIPTION
The included test failed prior to the small pod_sandbox change.

This is due to the usual gotcha of loop variables in go sharing the same
address, and the `toPodSandboxStatus` function returns references to
parts of that struct, which end up becoming wrong after another loop.

I'm pretty sure this explains a lot of troubles I've had with kubelet not being able to find some pod UIDs.