### PR TITLE
tests: add basic integ test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all build-in-rkt glide generate test clean
+.PHONY: all build-in-rkt glide generate test integ clean
 
 all:
 	go build -o bin/rktlet ./cmd/server/main.go
@@ -33,6 +33,9 @@ generate: ./hack/bin/mockery
 
 test:
 	go test ./rktlet/... ./journal2cri/...
+
+integ:
+	sudo -E go test ./tests/...
 
 clean:
 	rm -f ./bin/rktlet ./hack/bin/mockery ./bin/container/rktlet

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Tests
+
+This directory contains integration tests of the rktlet.
+
+They use the locally installed `rkt` and `systemd-run` binaries, which must be present in your path.
+
+They also require root privileges.

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package framework has utility functions and helpers for running integration
+// rktlet tests
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+
+	"github.com/kubernetes-incubator/rktlet/rktlet"
+	"golang.org/x/net/context"
+)
+
+func RequireRoot(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Fatalf("test requires root")
+	}
+}
+
+type TestContext struct {
+	*testing.T
+	Rktlet rktlet.ContainerAndImageService
+	TmpDir string
+}
+
+func Setup(t *testing.T) *TestContext {
+	RequireRoot(t)
+
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("rktlet_test_%d", time.Now().Unix()))
+	if err != nil {
+		t.Fatalf("unable to make tmpdir for test: %v", err)
+	}
+
+	rktRuntime, err := rktlet.New(&rktlet.Config{
+		RktDatadir: filepath.Join(tmpDir, "rkt_data"),
+	})
+	if err != nil {
+		t.Fatalf("unable to initialize rktlet: %v", err)
+	}
+
+	return &TestContext{
+		T:      t,
+		Rktlet: rktRuntime,
+		TmpDir: tmpDir,
+	}
+}
+
+func (t *TestContext) Teardown() {
+	allSandboxes, err := t.Rktlet.ListPodSandbox(context.Background(), &runtime.ListPodSandboxRequest{})
+	if err != nil {
+		t.Fatalf("expected to list sandboxes, got back: %v", err)
+	}
+
+	for i, _ := range allSandboxes.Items {
+		sandbox := allSandboxes.Items[i]
+		t.Logf("removing pod %q", sandbox.GetId())
+		_, err := t.Rktlet.RemovePodSandbox(context.Background(), &runtime.RemovePodSandboxRequest{
+			PodSandboxId: sandbox.Id,
+		})
+		if err != nil {
+			t.Errorf("error removing pod sandbox %q: %v", sandbox.GetId(), err)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("leaving tempdir for failed test: %v", t.TmpDir)
+	} else {
+		os.RemoveAll(t.TmpDir)
+	}
+}

--- a/tests/runtime/runtime_test.go
+++ b/tests/runtime/runtime_test.go
@@ -1,0 +1,43 @@
+package runtime_integ_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubernetes-incubator/rktlet/tests/framework"
+
+	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+func TestCreatesPodSandbox(t *testing.T) {
+	tc := framework.Setup(t)
+	defer tc.Teardown()
+
+	attempt := uint32(0)
+	uid := "testuid"
+	name := "testname"
+	def := "default"
+	logDir := filepath.Join(tc.TmpDir, "cri_logs", uid)
+	os.MkdirAll(logDir, 0777)
+	resp, err := tc.Rktlet.RunPodSandbox(context.Background(), &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Uid:       &uid,
+				Attempt:   &attempt,
+				Name:      &name,
+				Namespace: &def,
+			},
+			LogDirectory: &logDir,
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.GetPodSandboxId() == "" {
+		t.Errorf("Expected pod sandbox id to be nonempty")
+	}
+}


### PR DESCRIPTION
These don't get run by CI yet.

I'd like to do that as a followup.

These also do not pass in general until #61 is merged.