### PR TITLE
runtime: List Pod Sandbox filter

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -520,3 +520,28 @@ func (r *RktRuntime) getImageHash(ctx context.Context, imageName string) (string
 
 	return resp.GetImage().GetId(), err
 }
+
+func podSandboxStatusMatchesFilter(sbx *runtimeApi.PodSandboxStatus, filter *runtimeApi.PodSandboxFilter) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.Id != nil && filter.GetId() != sbx.GetId() {
+		return false
+	}
+
+	if filter.State != nil && filter.GetState() != sbx.GetState() {
+		return false
+	}
+
+	for key, val := range filter.LabelSelector {
+		sbxLabel, exists := sbx.Labels[key]
+		if !exists {
+			return false
+		}
+		if sbxLabel != val {
+			return false
+		}
+	}
+
+	return true
+}

--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -156,7 +156,9 @@ func (r *RktRuntime) ListPodSandbox(ctx context.Context, req *runtimeApi.ListPod
 			return nil, fmt.Errorf("error converting the status of pod sandbox %v: %v", p.UUID, err)
 		}
 
-		// TODO(yifan): Filter.
+		if !podSandboxStatusMatchesFilter(sandboxStatus, req.GetFilter()) {
+			continue
+		}
 
 		sandboxes = append(sandboxes, &runtimeApi.PodSandbox{
 			Id:        sandboxStatus.Id,


### PR DESCRIPTION
This was an easy todo that actually kinda matters a lot for not
confusing the Kubelet too horribly.

In the future, we can potentially make this more efficient by adding
such capabilities to rkt, but for now this is fine.

cc @s-urbaniak 