### PR TITLE
runtime: privileged => all-run for the sandbox

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -327,11 +327,11 @@ func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile st
 	}
 
 	if req.GetConfig().GetLinux().GetSecurityContext().GetPrivileged() {
-		// TODO: this setting is inherited by all applications even though only
+		// TODO: the 'paths' setting is inherited by all applications even though only
 		// a subset of them may request to be privileged, however there is no way
-		// to modify this on a per-app basis currently, so this is the best we can
+		// to modify paths on a per-app basis currently, so this is the best we can
 		// do.
-		cmd = append(cmd, "--insecure-options=paths")
+		cmd = append(cmd, "--insecure-options=paths,all-run")
 	}
 
 	// Add port mappings only if it's not hostnetwork.

--- a/tests/runtime/runtime_test.go
+++ b/tests/runtime/runtime_test.go
@@ -87,19 +87,19 @@ func TestPrivileged(t *testing.T) {
 	privilegedCases := []struct {
 		Name          string
 		Command       string
-		ShouldContain string
+		ShouldContain []string
 	}{
 		// 1: caps
 		{
 			Name:          "capabilities",
 			Command:       "capsh --print",
-			ShouldContain: "cap_sys_admin",
+			ShouldContain: []string{"cap_sys_admin", "cap_net_admin"},
 		},
 		// 2: no path masking
 		{
 			Name:          "unmasked-sysfs",
 			Command:       `ls /sys/fs/cgroup && echo success`,
-			ShouldContain: "success",
+			ShouldContain: []string{"success"},
 		},
 		// 3. RW sysfs and proc. TODO, currently rkt does not support this
 		// $ touch /proc/sys/vm/panic_on_oom
@@ -108,7 +108,7 @@ func TestPrivileged(t *testing.T) {
 		{
 			Name:          "seccomp",
 			Command:       "mount -o remount / && echo success",
-			ShouldContain: "success",
+			ShouldContain: []string{"success"},
 		},
 		// 6: device cgroup: TODO, currently rkt does not support this
 		// 7: All devices from the host: TODO, currently rkt does not support this
@@ -136,7 +136,8 @@ func TestPrivileged(t *testing.T) {
 			t.Fatalf("%s: expected %d, got %d: %v", testCase.Name, 0, exitCode, output)
 		}
 
-		assert.Contains(t, output, testCase.ShouldContain)
+		for _, el := range testCase.ShouldContain {
+			assert.Contains(t, output, el)
+		}
 	}
-
 }


### PR DESCRIPTION
This fixes an oversight in #80. The sandbox needs all privileges in order to grant them to individual processes, and the test wasn't good enough to catch that since the sandbox always had sys_admin regardless

cc @s-urbaniak 