### PR TITLE
tests: setup a local GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.glide/
 /bin
 /hack/bin
+/.gopath/

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -63,11 +63,15 @@ type TestContext struct {
 }
 
 func Setup(t *testing.T) *TestContext {
+	var err error
 	RequireRoot(t)
 
-	tmpDir, err := ioutil.TempDir(os.Getenv("TMPDIR"), fmt.Sprintf("rktlet_test_%d", time.Now().Unix()))
-	if err != nil {
-		t.Fatalf("unable to make tmpdir for test: %v", err)
+	tmpDir := os.Getenv("RKTLET_TESTDIR")
+	if tmpDir == "" {
+		tmpDir, err = ioutil.TempDir(os.Getenv("TMPDIR"), fmt.Sprintf("rktlet_test_%d", time.Now().Unix()))
+		if err != nil {
+			t.Fatalf("unable to make tmpdir for test: %v", err)
+		}
 	}
 
 	rktRuntime, err := rktlet.New(&rktlet.Config{
@@ -133,7 +137,10 @@ func (t *TestContext) Teardown() {
 		}
 	}
 
-	os.RemoveAll(t.TmpDir)
+	tmpDir := os.Getenv("RKTLET_TESTDIR")
+	if tmpDir == "" {
+		os.RemoveAll(t.TmpDir)
+	}
 }
 
 func (t *TestContext) PullImages() {

--- a/tests/runtime/runtime_test.go
+++ b/tests/runtime/runtime_test.go
@@ -75,7 +75,8 @@ func TestPrivileged(t *testing.T) {
 	tc := framework.Setup(t)
 	defer tc.Teardown()
 
-	p := tc.RunPod("test_privileged", &runtime.PodSandboxConfig{
+	podName := "test_privileged"
+	p := tc.RunPod(podName, &runtime.PodSandboxConfig{
 		Linux: &runtime.LinuxPodSandboxConfig{
 			SecurityContext: &runtime.LinuxSandboxSecurityContext{
 				Privileged: boolptr(true),
@@ -116,6 +117,7 @@ func TestPrivileged(t *testing.T) {
 	}
 
 	for i, testCase := range privilegedCases {
+		t.Logf("Checking for %q on pod %q", testCase.Name, podName)
 		runConfig := &runtime.ContainerConfig{
 			Image: &runtime.ImageSpec{
 				Image: strptr(tc.ImageRef(framework.TestImageFedora)),


### PR DESCRIPTION
This sets up a local GOPATH under `.gopath`, used for building and testing.
It also speeds up integration tests by using a single tempdir for all runs.