### PR TITLE
rktlet: make stage1-name configurable

### DIFF
--- a/cmd/server/options/options.go
+++ b/cmd/server/options/options.go
@@ -37,4 +37,5 @@ func (s *RktletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RktPath, "rkt-path", s.RktPath, "Path of rkt binary. Leave empty to use the first rkt in $PATH.")
 	fs.StringVar(&s.RktDatadir, "rkt-data-dir", s.RktDatadir, "Path to rkt's data directory. Defaults to '/var/lib/rktlet/data'.")
 	fs.StringVar(&s.StreamServerAddress, "stream-server-address", s.StreamServerAddress, "Address to listen on for api-server streaming requests. MUST BE SECURED BY SOME EXTERNAL MECHANISM.")
+	fs.StringVar(&s.RktStage1Name, "rkt-stage1-name", s.RktStage1Name, "Name of an image to use as stage1. This needs to be specified as 'image:version'. If the image is present in the local store, the version can be ommitted.")
 }

--- a/rktlet/rktlet.go
+++ b/rktlet/rktlet.go
@@ -57,7 +57,7 @@ func New(config *Config) (ContainerAndImageService, error) {
 
 	imageStore := image.NewImageStore(image.ImageStoreConfig{CLI: rktCli})
 
-	rktRuntime, err := runtime.New(rktCli, init, imageStore, config.StreamServerAddress)
+	rktRuntime, err := runtime.New(rktCli, init, imageStore, config.StreamServerAddress, config.RktStage1Name)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +69,9 @@ func New(config *Config) (ContainerAndImageService, error) {
 }
 
 type Config struct {
-	RktDatadir string
-	RktPath    string
+	RktDatadir    string
+	RktPath       string
+	RktStage1Name string
 
 	// StreamServerAddress is the address the rktlet stream server should listen on.
 	// This address must be accessible by the api-server. However, it also allows

--- a/rktlet/runtime/log.go
+++ b/rktlet/runtime/log.go
@@ -33,7 +33,7 @@ import (
 const loggingHelperImage = "quay.io/coreos/rktlet-journal2cri:0.0.1"
 const loggingAppName = internalAppPrefix + "journal2cri"
 
-func (r *RktRuntime) initializeLoggingAppImage(ctx context.Context) error {
+func (r *RktRuntime) fetchLoggingAppImage(ctx context.Context) error {
 	imageName := loggingHelperImage
 	_, err := r.getImageHash(ctx, loggingHelperImage)
 	if err == nil {

--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -45,7 +45,7 @@ func (r *RktRuntime) RunPodSandbox(ctx context.Context, req *runtimeApi.RunPodSa
 	}
 
 	// Let the init process to run the pod sandbox.
-	command := generateAppSandboxCommand(req, podUUIDFile.Name())
+	command := generateAppSandboxCommand(req, podUUIDFile.Name(), r.stage1Name)
 
 	cmd := r.Command(command[0], command[1:]...)
 

--- a/rktlet/runtime/stage1.go
+++ b/rktlet/runtime/stage1.go
@@ -1,0 +1,46 @@
+/*
+ Copyright 2016 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+)
+
+func (r *RktRuntime) fetchStage1Image(ctx context.Context) error {
+	if r.stage1Name == "" {
+		return nil
+	}
+
+	_, err := r.getImageHash(ctx, r.stage1Name)
+	if err == nil {
+		return nil
+	}
+
+	glog.Infof("downloading %q stage1 image, this may take some time", r.stage1Name)
+	output, err := r.RunCommand("image", "fetch", "--no-store=true", "--full=true", r.stage1Name)
+	if err != nil {
+		return fmt.Errorf("unable to fetch image %q: %v", r.stage1Name, err)
+	}
+	if len(output) < 1 {
+		return fmt.Errorf("malformed fetch image response for %q; must include image id: %v", r.stage1Name, output)
+	}
+	glog.Infof("finished downloading stage1 image")
+
+	return err
+}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -78,6 +78,7 @@ func Setup(t *testing.T) *TestContext {
 	rktRuntime, err := rktlet.New(&rktlet.Config{
 		RktDatadir:          filepath.Join(tmpDir, "rkt_data"),
 		StreamServerAddress: "127.0.0.1:0", // :0 so multiple setup instances don't conflict
+		RktStage1Name:       os.Getenv("RKT_STAGE1_NAME"),
 	})
 	if err != nil {
 		t.Fatalf("unable to initialize rktlet: %v", err)

--- a/tests/runtime/runtime_test.go
+++ b/tests/runtime/runtime_test.go
@@ -50,8 +50,9 @@ func TestHostNetwork(t *testing.T) {
 		},
 	}
 	output, exitCode := p.RunContainerToExit(context.TODO(), runConfig)
+	t.Logf("container output:\n%v", output)
 	if exitCode != 0 {
-		t.Fatalf("expected %d, got %d: %v", 0, exitCode, output)
+		t.Fatalf("expected %d, got %d", 0, exitCode)
 	}
 
 	// Due to https://github.com/coreos/rkt/issues/3473 we need to trim spaces for each line


### PR DESCRIPTION
The current rkt integration makes it possible to configure the stage1
image so we should do the same in the rktlet.