### PR TITLE
runtime/exec: do not mix errors and status codes

### DIFF
--- a/rktlet/runtime/exec.go
+++ b/rktlet/runtime/exec.go
@@ -50,10 +50,13 @@ func (r *RktRuntime) ExecSync(ctx context.Context, req *runtimeapi.ExecSyncReque
 	// TODO: Respect req.Timeout
 	exitCode := int32(0)
 	err := r.execShim.Exec(req.ContainerId, req.Cmd, nil, ioutils.WriteCloserWrapper(&stdout), ioutils.WriteCloserWrapper(&stderr), false, nil)
-	if exitErr, ok := err.(utilexec.ExitError); ok {
+	exitErr, ok := err.(utilexec.ExitError)
+	if ok {
 		exitCode = int32(exitErr.ExitStatus())
 	}
-	if err != nil {
+
+	// rktlet internal error
+	if !ok && err != nil {
 		return nil, err
 	}
 

--- a/tests/runtime/runtime_test.go
+++ b/tests/runtime/runtime_test.go
@@ -185,6 +185,14 @@ func TestExecSync(t *testing.T) {
 	assert.Nil(t, err, "could not get container ID")
 	fmt.Printf("got containerID %s\n", containerID)
 
+	dummyRes, err := tc.Rktlet.ExecSync(context.TODO(), &runtime.ExecSyncRequest{
+		ContainerId: containerID,
+		Cmd:         []string{"sh", "-c", "exit 17"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, dummyRes)
+	assert.Equal(t, int32(17), dummyRes.ExitCode)
+
 	execRes, err := tc.Rktlet.ExecSync(context.TODO(), &runtime.ExecSyncRequest{
 		ContainerId: containerID,
 		Cmd:         []string{"sh", "-c", "echo 42 > /exit; echo success; sleep 0.5"},


### PR DESCRIPTION
A bug in Exec() prevented error status codes from being passed
back to CRI, misrouting them instead as rktlet errors.