### PR TITLE
runtime: quote env variables for they might contain spaces

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -169,6 +169,16 @@ func getImageName(annotations map[string]string) string {
 	return name
 }
 
+func generateEnvironmentArgs(envs []*runtimeApi.KeyValue) []string {
+	var args []string
+
+	for _, env := range envs {
+		args = append(args, fmt.Sprintf("--environment=%s='%s'", env.Key, strings.Replace(env.Value, `'`, `\'`, -1)))
+	}
+
+	return args
+}
+
 func generateAppAddCommand(req *runtimeApi.CreateContainerRequest, imageID string) ([]string, error) {
 	config := req.Config
 
@@ -201,9 +211,8 @@ func generateAppAddCommand(req *runtimeApi.CreateContainerRequest, imageID strin
 	}
 
 	// Add environments
-	for _, env := range config.Envs {
-		cmd = append(cmd, fmt.Sprintf("--environment=%s=%s", env.Key, env.Value))
-	}
+	envArgs := generateEnvironmentArgs(config.Envs)
+	cmd = append(cmd, envArgs...)
 
 	// Add Linux options. (resources, caps, uid, gid).
 	if linux := config.GetLinux(); linux != nil {

--- a/rktlet/runtime/helpers_test.go
+++ b/rktlet/runtime/helpers_test.go
@@ -198,3 +198,63 @@ func TestGeneratePortArgs(t *testing.T) {
 		assert.Equal(t, tt.result, generatePortArgs(tt.port), testHint)
 	}
 }
+
+func TestGenerateEnvironmentArgs(t *testing.T) {
+	tests := []struct {
+		env    []*runtimeApi.KeyValue
+		result []string
+	}{
+		// simple test
+		{
+			[]*runtimeApi.KeyValue{
+				&runtimeApi.KeyValue{
+					Key:   "PATH",
+					Value: "/bin:/usr/bin:/usr/sbin",
+				},
+			},
+			[]string{`--environment=PATH='/bin:/usr/bin:/usr/sbin'`},
+		},
+
+		// spaces
+		{
+			[]*runtimeApi.KeyValue{
+				&runtimeApi.KeyValue{
+					Key:   "GREETING",
+					Value: "hello world",
+				},
+			},
+			[]string{`--environment=GREETING='hello world'`},
+		},
+
+		// several env variables
+		{
+			[]*runtimeApi.KeyValue{
+				&runtimeApi.KeyValue{
+					Key:   "PATH",
+					Value: "/bin:/usr/bin:/usr/sbin",
+				},
+				&runtimeApi.KeyValue{
+					Key:   "GREETING",
+					Value: "hello world",
+				},
+			},
+			[]string{`--environment=PATH='/bin:/usr/bin:/usr/sbin'`, `--environment=GREETING='hello world'`},
+		},
+
+		// escaping
+		{
+			[]*runtimeApi.KeyValue{
+				&runtimeApi.KeyValue{
+					Key:   "LYRICS",
+					Value: "it's the final countdown",
+				},
+			},
+			[]string{`--environment=LYRICS='it\'s the final countdown'`},
+		},
+	}
+
+	for i, tt := range tests {
+		testHint := fmt.Sprintf("test case #%d", i)
+		assert.Equal(t, tt.result, generateEnvironmentArgs(tt.env), testHint)
+	}
+}


### PR DESCRIPTION
We also need to escape single quotes.