### PR TITLE
runtime: set hostname to host's if --net=host

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -365,6 +366,9 @@ func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile, s
 	// Add hostnetwork
 	if hasHostNetwork(req.GetConfig()) {
 		cmd = append(cmd, "--net=host", "--hosts-entry=host")
+		if hn, err := os.Hostname(); err == nil {
+			cmd = append(cmd, fmt.Sprintf("--hostname=%s", hn))
+		}
 	}
 
 	// Generate annotations.


### PR DESCRIPTION
Since host networking implies host UTS [[1]] and rkt doesn't support
sharing the host's UTS namespace, let's at least set the hostname to the
host's.

[1]: https://github.com/kubernetes/kubernetes/blob/088c198224c00f8402448b0cfff5b6689ea892fa/pkg/kubelet/dockershim/security_context.go#L185