### PR TITLE
rktlet/cli/init: set `--service-type=notify`

### DIFF
--- a/rktlet/cli/init.go
+++ b/rktlet/cli/init.go
@@ -40,7 +40,7 @@ func NewSystemd(systemdRunPath string, execer utilexec.Interface) Init {
 func (s *systemd) StartProcess(cgroupParent, command string, args ...string) (id string, err error) {
 	unitName := fmt.Sprintf("rktlet-%s", uuid.New())
 
-	cmdList := []string{s.systemdRunPath, "--unit=" + unitName, "--setenv=RKT_EXPERIMENT_APP=true"}
+	cmdList := []string{s.systemdRunPath, "--unit=" + unitName, "--setenv=RKT_EXPERIMENT_APP=true", "--service-type=notify"}
 	if cgroupParent != "" {
 		// The cgroup parent must have a suffix of .slice.
 		// If cgroupParent doesn't exist in some of the subsystems,


### PR DESCRIPTION
Otherwise, an error in the run command is not detected and `systemd-run`
returns 0 in any case. (`systemd-run false ; echo $?` versus
`systemd-run --service=notify false ; echo $?`)

With this change, an error in a transient unit (as described in
https://github.com/kubernetes-incubator/rktlet/issues/108) would be
easier to debug, as `RunPodSandbox` now returns the actual error to the
kubelet.