### PR TITLE
Convert cgroup-parent to a systemd slice name

### DIFF
--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -17,7 +17,9 @@ By default, the `rktlet` service will listen on a unix socket `/var/run/rktlet.s
 
 ```shell
 # In the Kubernetes repo's root dir.
-$ export LOG_LEVEL=6 CONTAINER_RUNTIME=remote
+$ export LOG_LEVEL=6
+$ export CGROUP_DRIVER=systemd
+$ export CONTAINER_RUNTIME=remote
 $ export CONTAINER_RUNTIME_ENDPOINT=/var/run/rktlet.sock
 $ export IMAGE_SERVICE_ENDPOINT=/var/run/rktlet.sock
 $ ./hack/local-up-cluster.sh

--- a/rktlet/cli/init_test.go
+++ b/rktlet/cli/init_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016-2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCgroupParentToSliceName(t *testing.T) {
+
+	testCases := []struct {
+		cgroupParent string
+		sliceName    string
+		failed       bool
+	}{
+		{
+			cgroupParent: "/kubepods.slice/kubepods-guaranteed.slice/kubepods-guaranteed-pod5c5979ec_9871_11e7_b58f_c85b763781a4.slice",
+			sliceName:    "kubepods-guaranteed-pod5c5979ec_9871_11e7_b58f_c85b763781a4.slice",
+			failed:       false,
+		},
+		{
+			cgroupParent: "/kubepods/besteffort/pod5c5979ec-9871-11e7-b58f-c85b763781a4",
+			sliceName:    "",
+			failed:       true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			sliceName, err := cgroupParentToSliceName(testCase.cgroupParent)
+			assert.Equal(t, testCase.failed, err != nil)
+			assert.Equal(t, testCase.sliceName, sliceName)
+		})
+	}
+
+}


### PR DESCRIPTION
When the kubelet is started with --cgroups-per-qos, it will request pods
to be created in a specific cgroup. Since rktlet starts rkt as a systemd
unit, it needs to specify a systemd slice name that represent the
requested cgroup.

Unfortunately, not all cgroup paths are representable as systemd slice
names. The Kubelet must be started with --cgroup-driver=systemd
(CGROUP_DRIVER=systemd in hack/local-up-cluster.sh), otherwise the
cgroupParent will not be convertible.

Fixes https://github.com/kubernetes-incubator/rktlet/issues/44

-----------------

TODO:
- [x] Test with hack/local-up-cluster.sh
  - [x] with CGROUP_DRIVER=systemd: it works
  - [x] without CGROUP_DRIVER=systemd: error in `kubelet.log`
- [x] Test with kube-spawn
