### PR TITLE
rktlet: make criLogDir default to /var/log/pods/rkt_uuid

### DIFF
--- a/rktlet/runtime/log.go
+++ b/rktlet/runtime/log.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -32,6 +33,7 @@ import (
 // is merged/released
 const loggingHelperImage = "quay.io/coreos/rktlet-journal2cri:0.0.1"
 const loggingAppName = internalAppPrefix + "journal2cri"
+const defaultPodLogDir string = "/var/log/pods"
 
 func (r *RktRuntime) fetchLoggingAppImage(ctx context.Context) error {
 	imageName := loggingHelperImage
@@ -52,7 +54,10 @@ func (r *RktRuntime) fetchLoggingAppImage(ctx context.Context) error {
 // addInternalLoggingApp adds the helper app for converting journald logs for this pod to cri logs
 func (r *RktRuntime) addInternalLoggingApp(ctx context.Context, rktUUID string, criLogDir string) error {
 	if criLogDir == "" {
-		return fmt.Errorf("unable to start logging: no cri log directory provided")
+		criLogDir = filepath.Join(defaultPodLogDir, rktUUID)
+	}
+	if err := os.MkdirAll(criLogDir, os.FileMode(0700)); err != nil {
+		return err
 	}
 
 	imageHash, err := r.getImageHash(ctx, loggingHelperImage)


### PR DESCRIPTION
If no LogDir is given to `RunPodSandbox()`, we should make rktlet run with `/var/log/pods/rkt_uuid` by default. Otherwise tools like cri-tools would fail like that:

```
remote_runtime.go:92] RunPodSandbox from runtime service failed:
rpc error: code = Unknown desc = unable to start logging:
no cri log directory provided
```