### PR TITLE
rktlet: add network plugin name flag

### DIFF
--- a/cmd/server/options/options.go
+++ b/cmd/server/options/options.go
@@ -38,4 +38,5 @@ func (s *RktletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RktDatadir, "rkt-data-dir", s.RktDatadir, "Path to rkt's data directory. Defaults to '/var/lib/rktlet/data'.")
 	fs.StringVar(&s.StreamServerAddress, "stream-server-address", s.StreamServerAddress, "Address to listen on for api-server streaming requests. MUST BE SECURED BY SOME EXTERNAL MECHANISM.")
 	fs.StringVar(&s.RktStage1Name, "rkt-stage1-name", s.RktStage1Name, "Name of an image to use as stage1. This needs to be specified as 'image:version'. If the image is present in the local store, the version can be ommitted.")
+	fs.StringVar(&s.NetworkPluginName, "net", "", "Name of the network plugin used in the cluster")
 }

--- a/rktlet/rktlet.go
+++ b/rktlet/rktlet.go
@@ -57,7 +57,12 @@ func New(config *Config) (ContainerAndImageService, error) {
 
 	imageStore := image.NewImageStore(image.ImageStoreConfig{CLI: rktCli})
 
-	rktRuntime, err := runtime.New(rktCli, init, imageStore, config.StreamServerAddress, config.RktStage1Name)
+	rktRuntime, err := runtime.New(rktCli,
+		init,
+		imageStore,
+		config.StreamServerAddress,
+		config.RktStage1Name,
+		config.NetworkPluginName)
 	if err != nil {
 		return nil, err
 	}
@@ -77,6 +82,8 @@ type Config struct {
 	// This address must be accessible by the api-server. However, it also allows
 	// arbitrary code execution within pods and must be secured.
 	StreamServerAddress string
+
+	NetworkPluginName string
 
 	// TODO, podcidr, networkdir, etc for cni
 }

--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -313,7 +313,7 @@ func generateAppAddCommand(req *runtimeApi.CreateContainerRequest, imageID strin
 	return cmd, nil
 }
 
-func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile, stage1Name string) []string {
+func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile, stage1Name, networkPluginName string) []string {
 	cmd := []string{"app", "sandbox", "--uuid-file-save=" + uuidfile}
 
 	// annotation takes preference over configuration
@@ -369,6 +369,8 @@ func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile, s
 		if hn, err := os.Hostname(); err == nil {
 			cmd = append(cmd, fmt.Sprintf("--hostname=%s", hn))
 		}
+	} else if networkPluginName != "" {
+		cmd = append(cmd, "--net="+networkPluginName)
 	}
 
 	// Generate annotations.

--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -45,7 +45,7 @@ func (r *RktRuntime) RunPodSandbox(ctx context.Context, req *runtimeApi.RunPodSa
 	}
 
 	// Let the init process to run the pod sandbox.
-	command := generateAppSandboxCommand(req, podUUIDFile.Name(), r.stage1Name)
+	command := generateAppSandboxCommand(req, podUUIDFile.Name(), r.stage1Name, r.networkPluginName)
 
 	cmd := r.Command(command[0], command[1:]...)
 

--- a/rktlet/runtime/rkt_runtime.go
+++ b/rktlet/runtime/rkt_runtime.go
@@ -34,10 +34,11 @@ type RktRuntime struct {
 	cli.CLI
 	cli.Init
 
-	execShim     *execShim
-	streamServer streaming.Server
-	imageStore   runtimeApi.ImageServiceServer
-	stage1Name   string
+	execShim          *execShim
+	streamServer      streaming.Server
+	imageStore        runtimeApi.ImageServiceServer
+	stage1Name        string
+	networkPluginName string
 }
 
 const internalAppPrefix = "rktletinternal-"
@@ -49,13 +50,15 @@ func New(
 	imageStore runtimeApi.ImageServiceServer,
 	streamServerAddr string,
 	stage1Name string,
+	networkPluginName string,
 ) (runtimeApi.RuntimeServiceServer, error) {
 	runtime := &RktRuntime{
-		CLI:        cli,
-		Init:       init,
-		imageStore: imageStore,
-		execShim:   NewExecShim(cli),
-		stage1Name: stage1Name,
+		CLI:               cli,
+		Init:              init,
+		imageStore:        imageStore,
+		execShim:          NewExecShim(cli),
+		stage1Name:        stage1Name,
+		networkPluginName: networkPluginName,
 	}
 
 	var err error


### PR DESCRIPTION
According to the CRI Networking Specification[[1]], the runtime shim is
responsible of managing pod's network life cycle. However, the current
CRI API doesn't expose options like `network-plugin`, `cni-bin-dir`, or
`cni-conf-dir`.

This adds a new `--net` option to the rktlet so users can specify what
network they want to use for pods. We rely on rkt to set up the network
so these are the paths where rkt looks for CNI configurations and
binaries:

* Network configurations: `/etc/rkt/net.d`
* Plugin binaries: `/usr/lib/rkt/plugins/net`

Note that rkt also includes some plugins[[2]] in the default stage1.

[1]: https://github.com/kubernetes/community/blob/c1eab08/contributors/devel/kubelet-cri-networking.md
[2]: https://github.com/rkt/rkt/blob/v1.28.1/Documentation/networking/overview.md#built-in-network-types