### PR TITLE
rktlet/image: fix nil dereference in RemoveImage()

### DIFF
--- a/rktlet/image/imagestore.go
+++ b/rktlet/image/imagestore.go
@@ -64,6 +64,9 @@ func (s *ImageStore) RemoveImage(ctx context.Context, req *runtime.RemoveImageRe
 	if err != nil {
 		return nil, err
 	}
+	if img.Image == nil {
+		return nil, fmt.Errorf("Image does not exist")
+	}
 
 	if _, err := s.RunCommand("image", "rm", img.Image.Id); err != nil {
 		return nil, fmt.Errorf("failed to remove the image: %v", err)


### PR DESCRIPTION
`runtime.RemoveImageResponse.Image` can be nil, so we need to check for that Image being nil again.

Otherwise it panics like this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x88d3a4]

goroutine 79 [running]:
.../rktlet/image.(*ImageStore).RemoveImage(0xc4200ab640, 0x7f4074eee1d0,
0xc420085050, 0xc42012e1d0, 0xc197a0, 0xc4201cb101, 0xc42012e1d0)
        .../.gopath/src/github.com/kubernetes-incubator/rktlet/rktlet/image/imagestore.go:68 +0xe4
```