### PR TITLE
rktlet/runtime: make use of canonical image name

### DIFF
--- a/rktlet/image/imagestore.go
+++ b/rktlet/image/imagestore.go
@@ -205,14 +205,13 @@ func (s *ImageStore) getImageUser(manifest *appcschema.ImageManifest) string {
 
 // PullImage pulls an image into the store
 func (s *ImageStore) PullImage(ctx context.Context, req *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
-
-	canonicalImageName, err := util.ApplyDefaultImageTag(req.Image.Image)
+	canonicalImageName, err := util.GetCanonicalImageName(req.Image.GetImage())
 	if err != nil {
 		return nil, fmt.Errorf("unable to default tag for img %q, %v", req.Image.Image, err)
 	}
 
 	// TODO auth
-	output, err := s.RunCommand("image", "fetch", "--pull-policy=update", "--full=true", "docker://"+canonicalImageName)
+	output, err := s.RunCommand("image", "fetch", "--pull-policy=update", "--full=true", canonicalImageName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch image %q: %v", canonicalImageName, err)
 	}

--- a/rktlet/util/image_test.go
+++ b/rktlet/util/image_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestCanonicalImageName(t *testing.T) {
+	for i, tt := range []struct {
+		inName       string
+		expectedName string
+	}{
+		{
+			"busybox",
+			"docker://busybox:latest",
+		},
+		{
+			"docker://busybox",
+			"docker://busybox:latest",
+		},
+		{
+			"busybox:latest",
+			"docker://busybox:latest",
+		},
+		{
+			"docker://busybox:latest",
+			"docker://busybox:latest",
+		},
+		{
+			"sha512-72b96529483a709900dae6277618028651ef338702dcaa361fa705884c85181a",
+			"sha512-72b96529483a709900dae6277618028651ef338702dcaa361fa705884c85181a",
+		},
+	} {
+		outName, err := GetCanonicalImageName(tt.inName)
+		if err != nil {
+			t.Errorf("GetCanonicalImageName %d returned error: %v", i, err)
+		}
+
+		if tt.expectedName != outName {
+			t.Errorf("GetCanonicalImageName %d expected %v got %v: %v", i, tt.expectedName, outName, err)
+		}
+	}
+}


### PR DESCRIPTION
If `rkt add app` runs with an image name without a prefix `docker://`, add a prefix `docker://`. If the image name doesn't contain `:`, try to change it to a canonical name like "busybox:latest".

This is especially needed for testing with cri tools.

Partly covers https://github.com/kubernetes-incubator/rktlet/issues/131