### PR TITLE
rktlet/runtime: sanitize ACName before for running rkt app

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,21 @@
+## Limitations
+
+### sanitized app names
+
+`rkt app` could fail if it runs with an app name that contains uppercase
+letters, because the [appc spec][acname] does not allow uppercase letters.
+It requires an ACName of lowercase letters plus `"-"`.
+So even if a client passes to rktlet an input name with uppercase letters
+like `FooBar`, rktlet will sanitize the string to lowercase letters like
+`foobar`, e.g.:
+
+```shell
+$ sudo rkt app add 01234567-89ab-cdef-0123-456789abcdef docker://busybox:latest \
+  --name=foobar
+```
+
+However, the approach has a limitation. If two apps are added to a pod,
+one with a name `FooBar`, another with `foobar`, it will fail because
+both will be sanitized to the same name `foobar`.
+
+[acname]: https://github.com/appc/spec/blob/v0.8.11/schema/types/acname.go#L38..L45

--- a/rktlet/runtime/helpers_test.go
+++ b/rktlet/runtime/helpers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2016-2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -196,5 +196,64 @@ func TestGeneratePortArgs(t *testing.T) {
 	for i, tt := range tests {
 		testHint := fmt.Sprintf("test case #%d", i)
 		assert.Equal(t, tt.result, generatePortArgs(tt.port), testHint)
+	}
+}
+
+func TestBuildAppName(t *testing.T) {
+	tests := []struct {
+		inputAttempt  uint32
+		inputName     string
+		resultAppName string
+	}{
+		// Case 0, normal lowercase characters
+		{
+			0,
+			"containername",
+			"0-containername",
+		},
+		// Case 1, convertion from uppercase to lowercase
+		{
+			0,
+			"ContainerName",
+			"0-containername",
+		},
+	}
+
+	for i, tt := range tests {
+		testHint := fmt.Sprintf("test case #%d", i)
+		appName, err := buildAppName(tt.inputAttempt, tt.inputName)
+		if err != nil {
+			t.Errorf("error building app name from container name %s: %v\n", tt.inputName, err)
+			continue
+		}
+		assert.Equal(t, tt.resultAppName, appName, testHint)
+	}
+}
+
+func TestParseContainerID(t *testing.T) {
+	tests := []struct {
+		inputID       string
+		resultAppName string
+	}{
+		// Case 0, normal lowercase characters
+		{
+			"01234567-89ab-cdef-0123-456789abcdef:containerid",
+			"containerid",
+		},
+		// Case 1, convertion from uppercase to lowercase
+		{
+			"01234567-89ab-cdef-0123-456789abcdef:ContainerID",
+			"containerid",
+		},
+	}
+
+	for i, tt := range tests {
+		testHint := fmt.Sprintf("test case #%d", i)
+		_, appName, err := parseContainerID(tt.inputID)
+		if err != nil {
+			t.Errorf("error parsing container ID %s: %v\n", tt.inputID, err)
+			continue
+		}
+		assert.Equal(t, tt.resultAppName, appName, testHint)
 	}
 }

--- a/rktlet/runtime/rkt_runtime.go
+++ b/rktlet/runtime/rkt_runtime.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2016-2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -139,7 +139,10 @@ func (r *RktRuntime) CreateContainer(ctx context.Context, req *runtimeApi.Create
 		return nil, err
 	}
 
-	appName := buildAppName(req.Config.Metadata.Attempt, req.Config.Metadata.Name)
+	appName, err := buildAppName(req.Config.Metadata.Attempt, req.Config.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
 	containerID := buildContainerID(req.PodSandboxId, appName)
 
 	return &runtimeApi.CreateContainerResponse{ContainerId: containerID}, nil


### PR DESCRIPTION
As appc spec does not allow lowercase characters in ACName, we should sanitize ACName before running `rkt app`, for subcommands `add`, `exec`, `rm`, `start`, `status`, and `stop`. Otherwise each command will fail when app name contains an uppercase character like:

```
error adding app to pod: ACName must contain only lower case
alphanumeric characters plus "-"
```

Fixes https://github.com/kubernetes-incubator/rktlet/issues/134