### PR TITLE
rktlet/image: take care of image name written as hash string

### DIFF
--- a/rktlet/util/image.go
+++ b/rktlet/util/image.go
@@ -73,3 +73,12 @@ func GetCanonicalImageName(imageName string) (string, error) {
 
 	return imageID, nil
 }
+
+func ExistInSlice(inSlice []string, key string) bool {
+	for _, v := range inSlice {
+		if v == key {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
In `ImageStatus()`, we need to take care of not only a human-readable string to be found in RepoTags, but also a pure hash string like  `"sha512-..."`. Otherwise critools tests will fail like below:

```                                                                                            
E0927 13:16:48.789812   13017 remote_image.go:130]                                             
RemoveImage "sha512-90e41be10f11188676633f562cd98822686928b80cda76bd8529a753f9b5d890"          
from image service failed: rpc error: code = Unknown desc = Image does not exist               
Sep 27 13:16:48.789: INFO: Unexpected error occurred: rpc error:                               
code = Unknown desc = Image does not exist                                                     
```

Fixes https://github.com/kubernetes-incubator/rktlet/issues/136
Depends on https://github.com/kubernetes-incubator/rktlet/pull/133