### PR TITLE
rktlet/cli: fix regexp to check for error string

### DIFF
--- a/rktlet/cli/errors.go
+++ b/rktlet/cli/errors.go
@@ -19,7 +19,7 @@ package cli
 import "regexp"
 
 // pod "379ae074-f1ca-4bdc-8493-e7278b00009f" is already stopped
-var alreadyStoppedRegex = regexp.MustCompile(`^pod "[^"]+" is already stopped$`)
+var alreadyStoppedRegex = regexp.MustCompile(`pod "[^"]+" is already stopped`)
 
 // RktStopIsNotExistError determines if an error resulting from running `rkt
 // stop` or `rkt app stop` is the result of the pod already being stopped
@@ -31,7 +31,7 @@ func RktStopIsAlreadyStoppedError(err error) bool {
 }
 
 // stop: cannot get pod: no matches found for "37edaae0-f048-4db5-b3fb-c0de3aa8e9d8"
-var isNotExistStopError = regexp.MustCompile(`^stop: cannot get pod: no matches found for "[^"]+"$`)
+var isNotExistStopError = regexp.MustCompile(`stop: cannot get pod: no matches found for "[^"]+"`)
 
 func RktStopIsNotExistError(err error) bool {
 	if err == nil {


### PR DESCRIPTION
When `rkt stop` returns error because of UUID mismatch, the output Error string is not simply like `"cannot get pod: no matches found for ..."`, but actually like below:

```
failed to run stop [--force=false 3c0ec67e-c02a-41b5-b053-e1b5d6e2fe06]: exit status 254 output: stop: cannot get pod: no matches found for "3c0ec67e-c02a-41b5-b053-e1b5d6e2fe06" stop: failed to stop 1 pod(s)
```
(in one string)

That's why regexp matching doesn't work. The substring `cannot get pod...` is neither located in the beginning of the input string, nor at the end of the string. As a result, `rkt stop` always fails in case of UUID mismatch, as `RktStopIsNotExistError()` always returns false. That's why critools tests fail like:

```
E0927 16:45:09.004685    7605 remote_runtime.go:115] StopPodSandbox "51b1d5fb-9546-4e78-b11d-63dd5029adf0" from runtime service failed: rpc error: code = Unknown desc = failed to run stop [--force=false 51b1d5fb-9546-4e78-b11d-63dd5029adf0]: exit status 254
output: stop: cannot get pod: no matches found for "51b1d5fb-9546-4e78-b11d-63dd5029adf0"
```
Fix regexp by removing `^` and `$` from regexp.

Fixes https://github.com/kubernetes-incubator/rktlet/issues/138