### PR TITLE
runtime: start sandboxes with --debug

### DIFF
--- a/rktlet/runtime/helpers.go
+++ b/rktlet/runtime/helpers.go
@@ -400,7 +400,7 @@ func maybeCreateHostPathVolume(mount *runtimeApi.Mount) (created bool, err error
 }
 
 func generateAppSandboxCommand(req *runtimeApi.RunPodSandboxRequest, uuidfile, stage1Name, networkPluginName string) ([]string, error) {
-	cmd := []string{"app", "sandbox", "--uuid-file-save=" + uuidfile}
+	cmd := []string{"app", "--debug", "sandbox", "--uuid-file-save=" + uuidfile}
 
 	// annotation takes preference over configuration
 	if val, ok := req.Config.Annotations[k8sRktStage1NameAnno]; ok {


### PR DESCRIPTION
Otherwise, if `rkt app add` or `rkt app start` fails, we won't get any
logs in the journal and we'll be blind to the causes of the failure.

With this, users can at least run on the host:

    # journalctl -M rkt-$POD_UUID

and see why the app failed to start.

As a complete solution, we should somehow capture this journal output
and propagate it to the error returned in StartContainer().