### PR TITLE
image, runtime: do not ignore output from RunCommand

### DIFF
--- a/rktlet/image/imagestore.go
+++ b/rktlet/image/imagestore.go
@@ -68,8 +68,8 @@ func (s *ImageStore) RemoveImage(ctx context.Context, req *runtime.RemoveImageRe
 		return nil, fmt.Errorf("Image does not exist")
 	}
 
-	if _, err := s.RunCommand("image", "rm", img.Image.Id); err != nil {
-		return nil, fmt.Errorf("failed to remove the image: %v", err)
+	if output, err := s.RunCommand("image", "rm", img.Image.Id); err != nil {
+		return nil, fmt.Errorf("failed to remove the image, output: %s\nerr: %v", output, err)
 	}
 
 	return &runtime.RemoveImageResponse{}, nil
@@ -214,7 +214,7 @@ func (s *ImageStore) PullImage(ctx context.Context, req *runtime.PullImageReques
 	// TODO auth
 	output, err := s.RunCommand("image", "fetch", "--pull-policy=update", "--full=true", "docker://"+canonicalImageName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch image %q: %v", canonicalImageName, err)
+		return nil, fmt.Errorf("unable to fetch image %q\noutput: %s\nerr: %v", canonicalImageName, output, err)
 	}
 	if len(output) < 1 {
 		return nil, fmt.Errorf("malformed fetch image response for %q; must include image id: %v", canonicalImageName, output)

--- a/rktlet/runtime/pod_sandbox.go
+++ b/rktlet/runtime/pod_sandbox.go
@@ -98,7 +98,7 @@ func (r *RktRuntime) RunPodSandbox(ctx context.Context, req *runtimeApi.RunPodSa
 }
 
 func (r *RktRuntime) stopPodSandbox(ctx context.Context, id string, force bool) error {
-	_, err := r.RunCommand(
+	output, err := r.RunCommand(
 		"stop",
 		"--force="+strconv.FormatBool(force),
 		id,
@@ -109,7 +109,7 @@ func (r *RktRuntime) stopPodSandbox(ctx context.Context, id string, force bool) 
 			return err
 		}
 
-		glog.V(4).Infof("ignoring stop error for idempotency: %v", err)
+		glog.V(4).Infof("ignoring stop error for idempotency,\noutput: %s\nerr: %v", output, err)
 	}
 
 	if _, err := r.PodSandboxStatus(ctx, &runtimeApi.PodSandboxStatusRequest{PodSandboxId: id}); err != nil {
@@ -129,9 +129,9 @@ func (r *RktRuntime) RemovePodSandbox(ctx context.Context, req *runtimeApi.Remov
 	// the sandbox, they must be forcibly terminated
 	r.stopPodSandbox(ctx, req.PodSandboxId, true)
 
-	_, err := r.RunCommand("rm", req.PodSandboxId)
+	output, err := r.RunCommand("rm", req.PodSandboxId)
 
-	return &runtimeApi.RemovePodSandboxResponse{}, err
+	return &runtimeApi.RemovePodSandboxResponse{}, fmt.Errorf("output: %s\nerr: %v\n", output, err)
 }
 
 func (r *RktRuntime) PodSandboxStatus(ctx context.Context, req *runtimeApi.PodSandboxStatusRequest) (*runtimeApi.PodSandboxStatusResponse, error) {

--- a/rktlet/runtime/rkt_runtime.go
+++ b/rktlet/runtime/rkt_runtime.go
@@ -131,8 +131,8 @@ func (r *RktRuntime) CreateContainer(ctx context.Context, req *runtimeApi.Create
 	if err != nil {
 		return nil, err
 	}
-	if _, err := r.RunCommand(command[0], command[1:]...); err != nil {
-		return nil, err
+	if output, err := r.RunCommand(command[0], command[1:]...); err != nil {
+		return nil, fmt.Errorf("output: %s\n, err: %v", output, err)
 	}
 
 	appName, err := buildAppName(req.Config.Metadata.Attempt, req.Config.Metadata.Name)
@@ -151,8 +151,8 @@ func (r *RktRuntime) StartContainer(ctx context.Context, req *runtimeApi.StartCo
 		return nil, err
 	}
 
-	if _, err := r.RunCommand("app", "start", uuid, "--app="+appName); err != nil {
-		return nil, err
+	if output, err := r.RunCommand("app", "start", uuid, "--app="+appName); err != nil {
+		return nil, fmt.Errorf("output: %s\n, err: %v", output, err)
 	}
 	return &runtimeApi.StartContainerResponse{}, nil
 }
@@ -165,8 +165,8 @@ func (r *RktRuntime) StopContainer(ctx context.Context, req *runtimeApi.StopCont
 	}
 
 	// TODO(yifan): Support timeout.
-	if _, err := r.RunCommand("app", "stop", uuid, "--app="+appName); err != nil {
-		return nil, err
+	if output, err := r.RunCommand("app", "stop", uuid, "--app="+appName); err != nil {
+		return nil, fmt.Errorf("output: %s\n, err: %v", output, err)
 	}
 	return &runtimeApi.StopContainerResponse{}, nil
 }
@@ -237,8 +237,8 @@ func (r *RktRuntime) RemoveContainer(ctx context.Context, req *runtimeApi.Remove
 	}
 
 	// TODO(yifan): Support timeout.
-	if _, err := r.RunCommand("app", "rm", uuid, "--app="+appName); err != nil {
-		return nil, err
+	if output, err := r.RunCommand("app", "rm", uuid, "--app="+appName); err != nil {
+		return nil, fmt.Errorf("output: %s\n, err: %v", output, err)
 	}
 	return &runtimeApi.RemoveContainerResponse{}, nil
 }


### PR DESCRIPTION
We should not ignore output from `RunCommand()`, since rkt commands could return important messages via stderr upon errors. Let's return them together with error strings.

This change might be helpful especially when doing investigation on failures from the remote k8s clusters, where no special logs are available.
