### PR TITLE
cmd: add --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,16 @@ PKGPATH := ${PWD}/${GP}/src/${PARENT}/${PKG}
 GO_TEST_ARGS ?= 
 export GOPATH=${PWD}/${GP}
 
+ORG_PATH := github.com/kubernetes-incubator
+REPO_PATH := ${ORG_PATH}/rktlet
+VERSION := $(shell git describe --dirty --always)
+GLDFLAGS := -X ${REPO_PATH}/version.Version=${VERSION}
+
 all: build
 
 build: path-setup
 	cd "${PKGPATH}" && \
-	go build -o bin/rktlet ./cmd/server/main.go
+	go build -o bin/rktlet -ldflags "${GLDFLAGS}" ./cmd/server/main.go
 
 path-setup:
 	@if [ ! -d "${GP}" ]; then mkdir -p "${GP}/src/${PARENT}" "${GP}/pkg" "${GP}/bin"; fi && \

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -25,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/rktlet/cmd/server/options"
 	"github.com/kubernetes-incubator/rktlet/rktlet"
+	"github.com/kubernetes-incubator/rktlet/version"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
@@ -34,12 +36,21 @@ import (
 
 const defaultUnixSock = "/var/run/rktlet.sock"
 
+func printVersion() {
+	fmt.Println("rktlet version:", version.Version)
+}
+
 func main() {
 	s := options.NewRktletServer()
 	s.AddFlags(pflag.CommandLine)
 	flag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	if s.ShowVersion {
+		printVersion()
+		os.Exit(0)
+	}
 
 	exitCh := make(chan os.Signal, 1)
 	signal.Notify(exitCh, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/server/options/options.go
+++ b/cmd/server/options/options.go
@@ -24,6 +24,8 @@ import (
 
 type RktletServer struct {
 	*rktlet.Config
+
+	ShowVersion bool
 }
 
 func NewRktletServer() *RktletServer {
@@ -39,4 +41,5 @@ func (s *RktletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.StreamServerAddress, "stream-server-address", s.StreamServerAddress, "Address to listen on for api-server streaming requests. MUST BE SECURED BY SOME EXTERNAL MECHANISM.")
 	fs.StringVar(&s.RktStage1Name, "rkt-stage1-name", s.RktStage1Name, "Name of an image to use as stage1. This needs to be specified as 'image:version'. If the image is present in the local store, the version can be ommitted.")
 	fs.StringVar(&s.NetworkPluginName, "net", "", "Name of the network plugin used in the cluster")
+	fs.BoolVar(&s.ShowVersion, "version", false, "Show version")
 }

--- a/hack/bump-release
+++ b/hack/bump-release
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Attempt to bump the rktlet release to the specified version by replacing
+# all occurrences of the current/previous version.
+#
+# Generates two commits: the release itself and the bump to the next +git
+# version
+#
+# YMMV, no disclaimer or warranty, etc.
+
+# make sure we are running in a toplevel directory
+if ! [[ "$0" =~ "hack/bump-release" ]]; then
+	echo "This script must be run in a toplevel rktlet directory"
+	exit 255
+fi
+
+if ! [[ "$1" =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ ]]; then
+	echo "Usage: scripts/bump-release <VERSION>"
+	echo "   where VERSION must be vX.Y.Z"
+	exit 255
+fi
+
+function replace_stuff() {
+	local FROM
+	local TO
+	local REPLACE
+
+	FROM=$1
+	TO=$2
+	# escape special characters
+	REPLACE=$(sed -e 's/[]\/$*.^|[]/\\&/g'<<< $FROM)
+	shift 2
+	echo $* | xargs sed -i --follow-symlinks -e "s/$REPLACE/$TO/g"
+}
+
+function replace_version() {
+	replace_stuff $1 $2 version/version.go
+}
+
+NEXT=${1:1}             # 0.2.3
+NEXTGIT="${NEXT}+git"   # 0.2.3+git
+
+PREVGIT=$(grep -Po 'var Version = "\K[^"]*(?=")' version/version.go) # 0.1.2+git
+PREV=${PREVGIT::-4}     # 0.1.2
+
+replace_version $PREVGIT $NEXT
+git commit -am "version: bump to v${NEXT}"
+
+replace_version $NEXT $NEXTGIT
+git commit -am "version: bump to v${NEXTGIT}"

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+var Version = "0.0.0+git"


### PR DESCRIPTION
It's set at build-time to the output of `git describe --dirty --always`.

At the moment it just prints a git commit hash because there is no
annotated tag. When we add the first tag, it should start working as
intended and print versions in the format `0.1.0`,
`0.1.0-${COMMITS_SINCE_LAST_TAG}-${COMMIT_HASH}`, or
`0.1.0-${COMMITS_SINCE_LAST_TAG}-${COMMIT_HASH}-dirty`.